### PR TITLE
Update amazon-workspaces-security-groups.md

### DIFF
--- a/doc_source/amazon-workspaces-security-groups.md
+++ b/doc_source/amazon-workspaces-security-groups.md
@@ -5,16 +5,35 @@ When you register a directory with Amazon WorkSpaces, it creates two security gr
 **Important**  
 Do not delete the **\_workspacesMembers** security group\. If you delete this security group, your WorkSpaces won't function correctly and you won't be able to recreate this group and add it back\. 
 
-You can have an additional security group for WorkSpaces\. After you add the security group to the directory, it is associated with new WorkSpaces that you launch or existing WorkSpaces that you rebuild\.
+
+
+You can add the security group to the directory. Once a new security group is associated with a directory, new WorkSpaces that you launch or existing WorkSpaces that you rebuild will have the new group\.
 
 **To add a security group to a directory**
 
 1. Open the Amazon WorkSpaces console at [https://console\.aws\.amazon\.com/workspaces/](https://console.aws.amazon.com/workspaces/)\.
 
-1. In the navigation pane, choose **Directories**\.
+2. In the navigation pane, choose **Directories**\.
 
-1. Select the directory and choose **Actions**, **Update Details**\.
+3. Select the directory and choose **Actions**, **Update Details**\.
 
-1. Expand **Security Group** and select a security group\.
+4. Expand **Security Group** and select a security group\.
 
-1. Choose **Update and Exit**\.
+5. Choose **Update and Exit**\.
+
+
+You can also add a security group to the network interface of the an existing WorkSpace.  \.
+
+**To add a security group to an existing WorkSpace**
+Workspaces have Elastic Network Interfaces (ENI) which can controlled within the account. To add security groups to existing WorkSpaces the Security Group will need to be assigned to the ENI.  
+
+	1. Find the IP Address for each WorkSpace which needs to be updated.
+		a. Go to the WorkSpace console. https://console.aws.amazon.com/workspaces/
+		b. Expand the 1st WorkSpace and record the WorkSpace IP.
+		c. Repeat for the other WorkSpace.
+	2. Find the ENI for the WorkSpace and update the Security Group assignment. 
+		a. Go to the EC2 console. https://console.aws.amazon.com/ec2/.
+		b. Under Network & Security choose **Network Interfaces**.
+		c. Search for the IP addresses found in Step 1.
+		d. For the WorkSpace, select the ENI and choose **Actions**, then choose **Change Security Groups**.
+		d. Select the new Security Group(s).

--- a/doc_source/amazon-workspaces-security-groups.md
+++ b/doc_source/amazon-workspaces-security-groups.md
@@ -1,39 +1,48 @@
 # Security Groups for Your WorkSpaces<a name="amazon-workspaces-security-groups"></a>
 
-When you register a directory with Amazon WorkSpaces, it creates two security groups, one for directory controllers and another for WorkSpaces in the directory\. The security group for directory controllers has a name that consists of the directory identifier followed by \_controllers \(for example, d\-92673056e8\_controllers\) and the security group for WorkSpaces has a name that consists of the directory identifier followed by \_workspacesMembers \(for example, d\-926720fc18\_workspacesMembers\)\.
+When you register a directory with Amazon WorkSpaces, it creates two security groups, one for directory controllers and another for WorkSpaces in the directory\. The security group for directory controllers has a name that consists of the directory identifier followed by **\_controllers** \(for example, d\-12345678e1\_controllers\)\. The security group for WorkSpaces has a name that consists of the directory identifier followed by **\_workspacesMembers** \(for example, d\-123456fc11\_workspacesMembers\)\.
 
-**Important**  
-Do not delete the **\_workspacesMembers** security group\. If you delete this security group, your WorkSpaces won't function correctly and you won't be able to recreate this group and add it back\. 
+**Warning**  
+Do not delete the **\_workspacesMembers** security group\. If you delete this security group, your WorkSpaces won't function correctly, and you won't be able to recreate this group and add it back\. 
 
+You can add additional security groups to a directory\. After a new security group is associated with a directory, new WorkSpaces that you launch or existing WorkSpaces that you rebuild will have the new security group\.
 
+When you associate multiple security groups with a directory, the rules from each security group are effectively aggregated to create one set of rules\. We recommend condensing your security group rules as much as possible\.
 
-You can add the security group to the directory. Once a new security group is associated with a directory, new WorkSpaces that you launch or existing WorkSpaces that you rebuild will have the new group\.
+For more information about security groups, see [ Security Groups for Your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) in the *Amazon VPC User Guide*\.
 
 **To add a security group to a directory**
 
 1. Open the Amazon WorkSpaces console at [https://console\.aws\.amazon\.com/workspaces/](https://console.aws.amazon.com/workspaces/)\.
 
-2. In the navigation pane, choose **Directories**\.
+1. In the navigation pane, choose **Directories**\.
 
-3. Select the directory and choose **Actions**, **Update Details**\.
+1. Select the directory and choose **Actions**, **Update Details**\.
 
-4. Expand **Security Group** and select a security group\.
+1. Expand **Security Group** and select a security group\.
 
-5. Choose **Update and Exit**\.
+1. Choose **Update and Exit**\.
 
-
-You can also add a security group to the network interface of the an existing WorkSpace.  \.
+To add a security group to an existing WorkSpace without rebuilding it, you assign the new security group to the elastic network interface \(ENI\) of the WorkSpace\.
 
 **To add a security group to an existing WorkSpace**
-Workspaces have Elastic Network Interfaces (ENI) which can controlled within the account. To add security groups to existing WorkSpaces the Security Group will need to be assigned to the ENI.  
 
-	1. Find the IP Address for each WorkSpace which needs to be updated.
-		a. Go to the WorkSpace console. https://console.aws.amazon.com/workspaces/
-		b. Expand the 1st WorkSpace and record the WorkSpace IP.
-		c. Repeat for the other WorkSpace.
-	2. Find the ENI for the WorkSpace and update the Security Group assignment. 
-		a. Go to the EC2 console. https://console.aws.amazon.com/ec2/.
-		b. Under Network & Security choose **Network Interfaces**.
-		c. Search for the IP addresses found in Step 1.
-		d. For the WorkSpace, select the ENI and choose **Actions**, then choose **Change Security Groups**.
-		d. Select the new Security Group(s).
+1. Find the IP address for each WorkSpace that needs to be updated\.
+
+   1. Open the Amazon WorkSpaces console at [https://console\.aws\.amazon\.com/workspaces/](https://console.aws.amazon.com/workspaces/)\.
+
+   1. Expand each WorkSpace and record its WorkSpace IP address\.
+
+1. Find the ENI for each WorkSpace and update its security group assignment\.
+
+   1. Open the Amazon EC2 console at [https://console\.aws\.amazon\.com/ec2/](https://console.aws.amazon.com/ec2/)\.
+
+   1. Under **Network & Security**, choose **Network Interfaces**\.
+
+   1. Search for the first IP address that you recorded in Step 1\.
+
+   1. Select the ENI associated with the IP address, choose **Actions**, and then choose **Change Security Groups**\.
+
+   1. Select the new security group, and choose **Save**\.
+
+   1. Repeat this process as needed for any other WorkSpaces\. 


### PR DESCRIPTION
The existing security group documentation does not detail how to change the security groups of existing WorkSpaces. The inference from the original documentation is that WorkSpaces need to be recreated. This update provides detail on how to change the security groups of pre-existing WorkSpaces.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
